### PR TITLE
Simple typo fix

### DIFF
--- a/glge.js
+++ b/glge.js
@@ -3172,7 +3172,7 @@ GLGE.Text.prototype.GLRender=function(gl,renderType,pickindex){
 		
 		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.GLfaces);
 		gl.drawElements(gl.TRIANGLES, this.GLfaces.numItems, gl.UNSIGNED_SHORT, 0);
-		gl.scene.lastMaterail=null;
+		gl.scene.lastMaterial=null;
 	}
 }
 /**

--- a/glge_particles.js
+++ b/glge_particles.js
@@ -851,7 +851,7 @@ GLGE.ParticleSystem.prototype.GLRender=function(gl){
 	gl.stencilFunc(gl.ALWAYS, 0, 0);
 	gl.enable(gl.DEPTH_TEST);
 	
-	gl.scene.lastMaterail=null;
+	gl.scene.lastMaterial=null;
 }
 /**
 * @function Adds a particle system to the scene


### PR DESCRIPTION
Simple fix of the typo .lastMaterail to .lastMaterial in 2 spots.
