### PR TITLE
add index.htm for GLGE examples, makes it easier to run from local Apache server for Chrome

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,34 @@ GLGE requires nodejs, to build simply:
 For more options:
 >./build.js --help
 
+RUNNING THE EXAMPLES LOCALLY IN CHROME
+
+Chrome doesn't  support cross-origin requests which means running from a 
+file:/// url doesn't work. Here are some basic instructions for setting
+up a local Apache host for running the GLGE examples.
+
+Add a new entry in /etc/hosts:
+
+    127.0.0.1       glge.local
+
+Add an a new apache vhost:
+
+    <VirtualHost glge.local:80>
+       ServerName ometa-js
+       DocumentRoot /path/to/glge/
+       <Directory /path/to/glge-git>
+         Options +Indexes +FollowSymLinks +MultiViews +Includes
+         AllowOverride All
+         Order allow,deny
+         Allow from all
+         DirectoryIndex index.htm
+      </Directory>
+    </VirtualHost>
+
+Check the Apache configuration 'apachectl configtest' and if OK restart Apache.
+
+Now open: http://glge.local/examples/
+
 SUPPORT
 
 For help and support:

--- a/examples/index.htm
+++ b/examples/index.htm
@@ -1,0 +1,22 @@
+<html>
+<head>
+<title>GLGE Examples</title>
+<meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
+<body>
+  <h1>GLGE Examples</h1>
+  <ol>
+    <li><a href="2dfilterdemo/index.html">2dfilterdemo</a></li>
+    <li><a href="cubedemo/index.htm">cubedemo</a></li>
+    <li><a href="fogdemo/index.htm">fogdemo</a></li>
+    <li><a href="loddemo/lod.htm">loddemo</a></li>
+    <li><a href="pickingdemo/index.htm">pickingdemo</a></li>
+    <li><a href="shadowdemo/index.htm">shadowdemo</a></li>
+    <li><a href="collada/index.html">collada</a></li>
+    <li><a href="demoscene/index.htm">demoscene</a></li>
+    <li><a href="linedemo/index.htm">linedemo</a></li>
+    <li><a href="particlesdemo/index.htm">particlesdemo</a></li>
+    <li><a href="platformdemo/index.htm">platformdemo</a></li>
+    <li><a href="waterdemo/water.htm">waterdemo</a></li>
+  </ol>
+</body>
+</html>


### PR DESCRIPTION
I added an index.htm for GLGE examples, makes it easier to run from local Apache server for Chrome.

This is what I added to the readme:

RUNNING THE EXAMPLES LOCALLY IN CHROME

Chrome doesn't  support cross-origin requests which means running from a 
file:/// url doesn't work. Here are some basic instructions for setting
up a local Apache host for running the GLGE examples.

Add a new entry in /etc/hosts:

```
127.0.0.1       glge.local
```

Add an a new apache vhost:

```
<VirtualHost glge.local:80>
   ServerName ometa-js
   DocumentRoot /path/to/glge/
   <Directory /path/to/glge-git>
     Options +Indexes +FollowSymLinks +MultiViews +Includes
     AllowOverride All
     Order allow,deny
     Allow from all
     DirectoryIndex index.htm
  </Directory>
</VirtualHost>
```

Check the Apache configuration 'apachectl configtest' and if OK restart Apache.

Now open: http://glge.local/examples/
