### PR TITLE
HTML errors in examples

### DIFF
--- a/examples/2dfilterdemo/index.html
+++ b/examples/2dfilterdemo/index.html
@@ -3,10 +3,7 @@
 <head>
 
 <title>GLGE 2D Filters Demo</title>
-<script type="text/javascript" src="../../glge_math.js"></script> 
-<script type="text/javascript" src="../../glge.js"></script> 
-<script type="text/javascript" src="../../glge_filter2d.js"></script> 
-<script type="text/javascript" src="../../glge_collada.js"></script> 
+<script type="text/javascript" src="../../glge-compiled.js"></script>
 
 <style>
 body{margin:auto; background-color: #888; padding-top: 50px; font-family:sans; color: #666; font-size: 0.8em}

--- a/examples/cubedemo/index.htm
+++ b/examples/cubedemo/index.htm
@@ -1,5 +1,4 @@
 <html><head> 
-<html><head> 
  
  
 <title>GLGE</title> 

--- a/examples/particlesdemo/index.htm
+++ b/examples/particlesdemo/index.htm
@@ -1,5 +1,4 @@
 <html><head> 
-<html><head> 
  
  
 <title>GLGE</title> 

--- a/examples/platformdemo/index.htm
+++ b/examples/platformdemo/index.htm
@@ -1,5 +1,4 @@
 <html><head> 
-<html><head> 
  
  
 <title>GLGE</title> 

--- a/examples/shadowdemo/index.htm
+++ b/examples/shadowdemo/index.htm
@@ -3,12 +3,8 @@
  
 <title>GLGE</title> 
 <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
- 
- 
 
-<script type="text/javascript" src="../../glge_math.js"></script> 
-<script type="text/javascript" src="../../glge.js"></script> 
-<script type="text/javascript" src="../../glge_input.js"></script> 
+<script type="text/javascript" src="../../glge-compiled.js"></script>
 <style>
 body{background-color: #000;color: #fff;font-family:arial}
 </style>


### PR DESCRIPTION
There were still 2 examples which didn't refer to the library's .js file, these have been fixed in this request.
A few of the html files also had a double definition for the html- and head- tag, these are also fixed by the request.
