### PR TITLE
Fix Collada scene elements with non-Y_UP orientation

### DIFF
--- a/src/extra/glge_collada.js
+++ b/src/extra/glge_collada.js
@@ -1871,13 +1871,13 @@ GLGE.Collada.prototype.initVisualScene=function(){
         transformRoot = new GLGE.Group();
         this.addChild(transformRoot);
         if (up_axis[0]!="Z"&&up_axis[0]!="z") {
-            this.setRotMatrix(GLGE.Mat4([0, -1 , 0,  0,
+            transformRoot.setRotMatrix(GLGE.Mat4([0, -1 , 0,  0,
 					                     1, 0, 0, 0,
 					                     0, 0, 1, 0,
 					                     0, 0, 0, 1]));
           
         }else {
-            this.setRotMatrix(GLGE.Mat4([1, 0 , 0,  0,
+            transformRoot.setRotMatrix(GLGE.Mat4([1, 0 , 0,  0,
 					                     0, 0, 1, 0,
 					                     0, -1, 0, 0,
 					                     0, 0, 0, 1]));


### PR DESCRIPTION
I've found that some of my Collada files can't be placed in the correct orientation within a scene no matter how I set rot_x/y/z.  However, this was not true back in 2010, as you can see by comparing the online version of the "level demo" from glge.org vs. the same data using the current code.  This seems to be wrong both in v0.8 and in trunk.  I performed a bisection and found that the trouble began with this commit:

0abb11743fd554681fb7e2d0f23765e2298bbcee "reapplying collada fixes that were lost..."

The problem seems to be that the transformation to reorient the Z- or X-up input data is applied to the top level group and not to the transformRoot that appears to be created for that purpose.  Making this simple change restored my ability to orient included Collada files as desired within the scene;  I hope you will consider applying it.

Best Regards,
Jeff Trull
