### PR TITLE
Optimized Wavefront loader & Mesh.calcTangents

### DIFF
--- a/src/extra/glge_wavefront.js
+++ b/src/extra/glge_wavefront.js
@@ -277,20 +277,23 @@ GLGE.Wavefront.prototype.loaded=function(url,objfile){
 * creates a new multimaterial
 * @private
 */
-GLGE.Wavefront.prototype.createMultiMaterial=function(idxDataOrig,verts,norms,texCoords,faces,material,smooth){
+GLGE.Wavefront.prototype.createMultiMaterial=function(idxDataOrig,idxDataOrigMap,verts,norms,texCoords,faces,material,smooth){
 	//loop though the indexes to produce streams
 	var positions=[];
 	var normals=[];
 	var uv=[];
 	var newfaces=[];
 	var idxData=[];
+	var idxDataMap={};
 	for(var i=0;i<faces.length;i++){
 		var data=idxDataOrig[faces[i]];
-		if(idxData.indexOf(data)==-1 || !smooth){
+		var idx=idxDataMap[data];
+		if((typeof idx === "undefined") || !smooth){
 			idxData.push(data);
+			idxDataMap[data]=idxData.length-1;
 			newfaces.push(idxData.length-1);
 		}else{
-			newfaces.push(idxData.indexOf(data));
+			newfaces.push(idxDataMap[data]);
 		}
 	}
 	faces=newfaces;
@@ -333,6 +336,7 @@ GLGE.Wavefront.prototype.parseMesh=function(){
 	var norms=[];
 	var faces=[];
 	var idxData=[];
+	var idxDataMap={};
 	var vertoffset=0;
 	var smooth=true;
 	var material=new GLGE.Material;
@@ -346,14 +350,14 @@ GLGE.Wavefront.prototype.parseMesh=function(){
 							else smooth=false;
 					case "o":
 						if(faces.length>0){
-							this.createMultiMaterial(idxData,verts,norms,texCoords,faces,material,smooth);
+							this.createMultiMaterial(idxData,idxDataMap,verts,norms,texCoords,faces,material,smooth);
 							faces=[];
 							material=new GLGE.Material;
 						}
 						break;
 					case "usemtl":
 						if(faces.length>0){
-							this.createMultiMaterial(idxData,verts,norms,texCoords,faces,material,smooth);
+							this.createMultiMaterial(idxData,idxDataMap,verts,norms,texCoords,faces,material,smooth);
 							faces=[];
 						}
 						if(this.idMaterials.indexOf(data[1]) == -1)//Material no name 
@@ -373,10 +377,11 @@ GLGE.Wavefront.prototype.parseMesh=function(){
 					case "f":
 						var tmpface=[];
 						for(var j=1;j<data.length;j++){
-							var idx=idxData.indexOf(data[j]);
-							if(idx==-1 || !smooth){
+							var idx=idxDataMap[data[j]];
+							if((typeof idx === "undefined") || !smooth){
 								idxData.push(data[j]);
 								idx=idxData.length-1;
+								idxDataMap[data[j]]=idx;
 							}
 							tmpface.push(idx);
 						}
@@ -390,7 +395,7 @@ GLGE.Wavefront.prototype.parseMesh=function(){
 			}
 		}
 	}
-	this.createMultiMaterial(idxData,verts,norms,texCoords,faces,material,smooth);
+	this.createMultiMaterial(idxData,idxDataMap,verts,norms,texCoords,faces,material,smooth);
 };
 
 /**

--- a/src/geometry/glge_mesh.js
+++ b/src/geometry/glge_mesh.js
@@ -388,49 +388,58 @@ GLGE.Mesh.prototype.calcTangents=function(){
 			tangentArray[i]=0;
 		}
 		for(var i=0;i<this.faces.data.length;i=i+3){
-			var p1=[position[(parseInt(this.faces.data[i]))*3],position[(parseInt(this.faces.data[i]))*3+1],position[(parseInt(this.faces.data[i]))*3+2]];
-			var p2=[position[(parseInt(this.faces.data[i+1]))*3],position[(parseInt(this.faces.data[i+1]))*3+1],position[(parseInt(this.faces.data[i+1]))*3+2]];
-			var p3=[position[(parseInt(this.faces.data[i+2]))*3],position[(parseInt(this.faces.data[i+2]))*3+1],position[(parseInt(this.faces.data[i+2]))*3+2]];
+			var f1=parseInt(this.faces.data[i]);
+			var f2=parseInt(this.faces.data[i+1]);
+			var f3=parseInt(this.faces.data[i+2]);
+		
+			var p1=[position[f1*3],position[f1*3+1],position[f1*3+2]];
+			var p2=[position[f2*3],position[f2*3+1],position[f2*3+2]];
+			var p3=[position[f3*3],position[f3*3+1],position[f3*3+2]];
 			
-			var n1=[normal[(parseInt(this.faces.data[i]))*3],normal[(parseInt(this.faces.data[i]))*3+1],normal[(parseInt(this.faces.data[i]))*3+2]];
-			var n2=[normal[(parseInt(this.faces.data[i+1]))*3],normal[(parseInt(this.faces.data[i+1]))*3+1],normal[(parseInt(this.faces.data[i+1]))*3+2]];
-			var n3=[normal[(parseInt(this.faces.data[i+2]))*3],normal[(parseInt(this.faces.data[i+2]))*3+1],normal[(parseInt(this.faces.data[i+2]))*3+2]];
+			var n1=[normal[f1*3],normal[f1*3+1],normal[f1*3+2]];
+			var n2=[normal[f2*3],normal[f2*3+1],normal[f2*3+2]];
+			var n3=[normal[f3*3],normal[f3*3+1],normal[f3*3+2]];
 			
-			var uv1=[uv[(parseInt(this.faces.data[i]))*4],uv[(parseInt(this.faces.data[i]))*4+1]];
-			var uv2=[uv[(parseInt(this.faces.data[i+1]))*4],uv[(parseInt(this.faces.data[i+1]))*4+1]];
-			var uv3=[uv[(parseInt(this.faces.data[i+2]))*4],uv[(parseInt(this.faces.data[i+2]))*4+1]];
+			var uv1=[uv[f1*4],uv[f1*4+1]];
+			var uv2=[uv[f2*4],uv[f2*4+1]];
+			var uv3=[uv[f3*4],uv[f3*4+1]];
 			
 			var tb=this.tangentFromUV(p2,p1,p3,uv2,uv1,uv3,n2);
 			
-			if(!data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")]){
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")]=tb;
+			var d=[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",");
+			if(!data[d]){
+				data[d]=tb;
 			}else{
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][0][0]+=tb[0][0];
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][0][1]+=tb[0][1];
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][0][2]+=tb[0][2];
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][1][0]+=tb[1][0];
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][1][1]+=tb[1][1];
-				data[[p1[0],p1[1],p1[2],uv1[0],uv1[1],n1[0],n1[1],n1[2]].join(",")][1][2]+=tb[1][2];
+				data[d][0][0]+=tb[0][0];
+				data[d][0][1]+=tb[0][1];
+				data[d][0][2]+=tb[0][2];
+				data[d][1][0]+=tb[1][0];
+				data[d][1][1]+=tb[1][1];
+				data[d][1][2]+=tb[1][2];
 			}
-			if(!data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")]){
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")]=tb;
+			
+			d=[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",");
+			if(!data[d]){
+				data[d]=tb;
 			}else{
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][0][0]+=tb[0][0];
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][0][1]+=tb[0][1];
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][0][2]+=tb[0][2];
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][1][0]+=tb[1][0];
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][1][1]+=tb[1][1];
-				data[[p2[0],p2[1],p2[2],uv2[0],uv2[1],n2[0],n2[1],n2[2]].join(",")][1][2]+=tb[1][2];
+				data[d][0][0]+=tb[0][0];
+				data[d][0][1]+=tb[0][1];
+				data[d][0][2]+=tb[0][2];
+				data[d][1][0]+=tb[1][0];
+				data[d][1][1]+=tb[1][1];
+				data[d][1][2]+=tb[1][2];
 			}
-			if(!data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")]){
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")]=tb;
+			
+			d=[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",");
+			if(!data[d]){
+				data[d]=tb;
 			}else{
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][0][0]+=tb[0][0];
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][0][1]+=tb[0][1];
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][0][2]+=tb[0][2];
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][1][0]+=tb[1][0];
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][1][1]+=tb[1][1];
-				data[[p3[0],p3[1],p3[2],uv3[0],uv3[1],n3[0],n3[1],n3[2]].join(",")][1][2]+=tb[1][2];
+				data[d][0][0]+=tb[0][0];
+				data[d][0][1]+=tb[0][1];
+				data[d][0][2]+=tb[0][2];
+				data[d][1][0]+=tb[1][0];
+				data[d][1][1]+=tb[1][1];
+				data[d][1][2]+=tb[1][2];
 			}
 
 		}		


### PR DESCRIPTION
The repeated use of indexOf() for the idxData array in the Wavefront loader was slowing down parsing a lot. I added a map so that O(1) lookups can be used. It is especially noticeable for larger Wavefront files. The mesh loading still took too long because of calcTangents. Some simple optimizations yielded a 3x speed-up. My test file was 8 MiB and in total I could achieve a speed up from >10 minutes to 8 seconds.
