### PR TITLE
Pausing an animatable should pause all children

### DIFF
--- a/src/core/glge_animatable.js
+++ b/src/core/glge_animatable.js
@@ -385,10 +385,20 @@ GLGE.Animatable.prototype.isLooping=GLGE.Animatable.prototype.getLoop;
 * Sets the paused flag to GLGE.TRUE or GLGE.FALSE
 * @param  {boolean} value 
 */
-GLGE.Animatable.prototype.setPaused=function(value){
-	if(value) this.pauseTime=parseInt(new Date().getTime());
-		else this.animationStart=this.animationStart+(parseInt(new Date().getTime())-this.pauseTime);
+GLGE.Animatable.prototype.setPaused=function(value, now){
+	if(!now) now=parseInt(new Date().getTime())
+	if(value) this.pauseTime=parseInt(now);
+		else this.animationStart=this.animationStart+(parseInt(now)-this.pauseTime);
 	this.paused=value;
+
+	if(this.children){
+		for(var i=0;i<this.children.length;i++){
+			if(this.children[i].setPaused){
+				this.children[i].setPaused(value, now);
+			}
+		}
+	}
+
 	return this;
 }
 /**


### PR DESCRIPTION
I've had need to pause the animations on an entire scene. If the model
is complex, manually attempting to do this will cause about a ~1ms
difference between different bones on the model.

Having this not recurse by default can also cause unexpected behavior
when calling `setPause` on a scene. The scene will stop rendering, but
unpausing will cause it to jump forward to the frame it would have been
on otherwise.
