### PR TITLE
Fix inconsistencies in the behavior of `getFrameNumber`

### DIFF
--- a/src/core/glge_animatable.js
+++ b/src/core/glge_animatable.js
@@ -122,8 +122,8 @@ GLGE.Animatable.prototype.getName=function(){
 * @param {number} now the current time
 */
  GLGE.Animatable.prototype.getFrameNumber=function(now){
-	if(!this.startFrame) this.startFrame=this.animation.startFrame;
-	if(!this.animFrames) this.animFrames=this.animation.frames;
+	if(this.startFrame == null) this.startFrame=this.animation.startFrame;
+	if(this.animFrames == null) this.animFrames=this.animation.frames;
 	var frame;
 	if(!now) now=parseInt(new Date().getTime());
 	if(this.animFrames>1){
@@ -132,7 +132,7 @@ GLGE.Animatable.prototype.getName=function(){
 		}else{
 			frame=((parseFloat(now)-parseFloat(this.animationStart))/1000*this.frameRate)+1+this.startFrame; 
 			if(frame>=(this.animFrames+this.startFrame)){
-				frame=this.animFrames;
+				frame=this.animFrames+this.startFrame;
 			}
 		}
 	}else{


### PR DESCRIPTION
Setting the start frame or anim frames of an animatible to 0 is not the
same as that variable not being set. If `startFrame == 0` and
`animFrames == 307`, and `getFrameNumber()` returns 307 at the end of
an animation, then one can infer that starting at frame 100 would be
accomplished like so:

```
var frameCount = 307;

function jumpToFrame(frameNumber) {
  animatable.setStartFrame(frameNumber);
  animatable.setFrames(frameCount - frameNumber);
}
```

However, if that function were to be called with 307, the animation will
play from frame 307 to 614 (leading to unexpected results).

Additionally, if playing that entire animation from frame 100 to 307
results in `getFrameNumber()` returning 307 the moment the animation
ends, then it should continue returning 307, and not change to 207 30ms
later.
