### PR TITLE
Fix vertex shader precision

### DIFF
--- a/src/renderable/glge_object.js
+++ b/src/renderable/glge_object.js
@@ -584,7 +584,7 @@ GLGE.Object.prototype.GLGenerateShader=function(gl){
 	//Vertex Shader
 	var colors=UV=joints1=joints2=false;
 	var lights=gl.lights;
-	var vertexStr=["#ifdef GL_ES\nprecision mediump float;\n#endif\n#define GLGE_VERTEX\n"];
+	var vertexStr=["#ifdef GL_ES\nprecision highp float;\n#endif\n#define GLGE_VERTEX\n"];
 	var tangent=false;
 	if(!this.mesh.normals) this.mesh.calcNormals();
 	vertexStr.push("attribute vec3 position;\n");


### PR DESCRIPTION
All of the shaders use high precision except for one. This causes "Uniforms with the same name but different type/precision" errors in the latest version of Chrome. This pull changes the precision of the one outstanding medium precision shader to high precision, which fixes the problem.

Ref: https://code.google.com/p/chromium/issues/detail?id=378756
