### PR TITLE
Fixed Group.removeChild(obj) for when obj is not in the group.

### DIFF
--- a/src/core/glge_group.js
+++ b/src/core/glge_group.js
@@ -276,6 +276,8 @@ GLGE.Group.prototype.removeChild=function(child){
 				break;
 			}
 		}
+		if (!object)
+			return;
 	} else {
 		if (this.children.length <= child)
 			return;


### PR DESCRIPTION
If removeChild() is passed an object not in the group then the rest of
the method still still execute and attempt to call methods on `object`
which is undefined.
